### PR TITLE
Updated the readme suggested version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ To add this package as a local, per-project dependency to your project, simply a
 
     {
         "require": {
-            "sebastian/global-state": "*"
+            "sebastian/global-state": "1.0.*"
         }
     }


### PR DESCRIPTION
It's a bad idea to recommend people to use `*` as a version constraint.
