### PR TITLE
Restore global variables whose the value is null

### DIFF
--- a/src/Restorer.php
+++ b/src/Restorer.php
@@ -56,7 +56,7 @@ class Restorer
             if ($key != 'GLOBALS' &&
                 !in_array($key, $superGlobalArrays) &&
                 !$snapshot->blacklist()->isGlobalVariableBlacklisted($key)) {
-                if (isset($globalVariables[$key])) {
+                if (array_key_exists($key, $globalVariables)) {
                     $GLOBALS[$key] = $globalVariables[$key];
                 } else {
                     unset($GLOBALS[$key]);

--- a/tests/RestorerTest.php
+++ b/tests/RestorerTest.php
@@ -1,0 +1,103 @@
+<?php
+/*
+ * This file is part of the GlobalState package.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace SebastianBergmann\GlobalState;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Restorer.
+ */
+class RestorerTest extends TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        $GLOBALS['varBool'] = false;
+        $GLOBALS['varNull'] = null;
+        $_GET['varGet'] = 0;
+    }
+
+    /**
+     * Check global variables are correctly backuped and restored (unit test).
+     *
+     * @covers \SebastianBergmann\GlobalState\Restorer::restoreGlobalVariables
+     * @covers \SebastianBergmann\GlobalState\Restorer::restoreSuperGlobalArray
+     * @uses \SebastianBergmann\GlobalState\Blacklist::isGlobalVariableBlacklisted
+     * @uses \SebastianBergmann\GlobalState\Snapshot::__construct
+     * @uses \SebastianBergmann\GlobalState\Snapshot::blacklist
+     * @uses \SebastianBergmann\GlobalState\Snapshot::canBeSerialized
+     * @uses \SebastianBergmann\GlobalState\Snapshot::globalVariables
+     * @uses \SebastianBergmann\GlobalState\Snapshot::setupSuperGlobalArrays
+     * @uses \SebastianBergmann\GlobalState\Snapshot::snapshotGlobals
+     * @uses \SebastianBergmann\GlobalState\Snapshot::snapshotSuperGlobalArray
+     * @uses \SebastianBergmann\GlobalState\Snapshot::superGlobalArrays
+     * @uses \SebastianBergmann\GlobalState\Snapshot::superGlobalVariables
+     */
+    public function testRestorerGlobalVariable()
+    {
+        $snapshot = new Snapshot(null, true, false, false, false, false, false, false, false, false);
+        $restorer = new Restorer;
+        $restorer->restoreGlobalVariables($snapshot);
+
+        $this->assertArrayHasKey('varBool', $GLOBALS);
+        $this->assertEquals(false, $GLOBALS['varBool']);
+        $this->assertArrayHasKey('varNull', $GLOBALS);
+        $this->assertEquals(null, $GLOBALS['varNull']);
+        $this->assertArrayHasKey('varGet', $_GET);
+        $this->assertEquals(0, $_GET['varGet']);
+    }
+
+    /**
+     * Check global variables are correctly backuped and restored.
+     *
+     * The real test is the second, but the first has to be executed to backup the globals.
+     *
+     * @backupGlobals enabled
+     * @covers \SebastianBergmann\GlobalState\Restorer::restoreGlobalVariables
+     * @covers \SebastianBergmann\GlobalState\Restorer::restoreSuperGlobalArray
+     * @uses \SebastianBergmann\GlobalState\Blacklist::addClassNamePrefix
+     * @uses \SebastianBergmann\GlobalState\Blacklist::isGlobalVariableBlacklisted
+     * @uses \SebastianBergmann\GlobalState\Snapshot::__construct
+     * @uses \SebastianBergmann\GlobalState\Snapshot::blacklist
+     * @uses \SebastianBergmann\GlobalState\Snapshot::canBeSerialized
+     * @uses \SebastianBergmann\GlobalState\Snapshot::globalVariables
+     * @uses \SebastianBergmann\GlobalState\Snapshot::setupSuperGlobalArrays
+     * @uses \SebastianBergmann\GlobalState\Snapshot::snapshotGlobals
+     * @uses \SebastianBergmann\GlobalState\Snapshot::snapshotSuperGlobalArray
+     * @uses \SebastianBergmann\GlobalState\Snapshot::superGlobalArrays
+     * @uses \SebastianBergmann\GlobalState\Snapshot::superGlobalVariables
+     */
+    public function testIntegrationRestorerGlobalVariables()
+    {
+        $this->assertArrayHasKey('varBool', $GLOBALS);
+        $this->assertEquals(false, $GLOBALS['varBool']);
+        $this->assertArrayHasKey('varNull', $GLOBALS);
+        $this->assertEquals(null, $GLOBALS['varNull']);
+        $this->assertArrayHasKey('varGet', $_GET);
+        $this->assertEquals(0, $_GET['varGet']);
+    }
+
+    /**
+     * Check global variables are correctly backuped and restored.
+     *
+     * @depends testIntegrationRestorerGlobalVariables
+     */
+    public function testIntegrationRestorerGlobalVariables2()
+    {
+        $this->assertArrayHasKey('varBool', $GLOBALS);
+        $this->assertEquals(false, $GLOBALS['varBool']);
+        $this->assertArrayHasKey('varNull', $GLOBALS);
+        $this->assertEquals(null, $GLOBALS['varNull']);
+        $this->assertArrayHasKey('varGet', $_GET);
+        $this->assertEquals(0, $_GET['varGet']);
+    }
+}

--- a/tests/SnapshotTest.php
+++ b/tests/SnapshotTest.php
@@ -28,6 +28,12 @@ class SnapshotTest extends TestCase
      */
     private $blacklist;
 
+    public static function setUpBeforeClass()
+    {
+        $GLOBALS['varBool'] = false;
+        $GLOBALS['varNull'] = null;
+    }
+
     protected function setUp()
     {
         $this->blacklist = $this->createMock(Blacklist::class);
@@ -111,7 +117,32 @@ class SnapshotTest extends TestCase
     public function testIncludedFiles()
     {
         $snapshot = new Snapshot($this->blacklist, false, false, false, false, false, false, false, false, true);
-
         $this->assertContains(__FILE__, $snapshot->includedFiles());
+    }
+
+    /**
+     * Check global variable whose value is null are correctly backuped and restored.
+     *
+     * The real test is the second, but the first has to be executed to backup the globals.
+     *
+     * @backupGlobals enabled
+     */
+    public function testNullGlobalVariable()
+    {
+	$this->assertEquals(false, $GLOBALS['varBool']);
+        $this->assertArrayHasKey('varNull', $GLOBALS);
+        $this->assertEquals(null, $GLOBALS['varNull']);
+    }
+
+    /**
+     * Check global variable whose value is null are correctly backuped and restored.
+     *
+     * @depends testNullGlobalVariable
+     */
+    public function testNullGlobalVariable2()
+    {
+	$this->assertEquals(false, $GLOBALS['varBool']);
+        $this->assertArrayHasKey('varNull', $GLOBALS);
+        $this->assertEquals(null, $GLOBALS['varNull']);
     }
 }

--- a/tests/SnapshotTest.php
+++ b/tests/SnapshotTest.php
@@ -28,12 +28,6 @@ class SnapshotTest extends TestCase
      */
     private $blacklist;
 
-    public static function setUpBeforeClass()
-    {
-        $GLOBALS['varBool'] = false;
-        $GLOBALS['varNull'] = null;
-    }
-
     protected function setUp()
     {
         $this->blacklist = $this->createMock(Blacklist::class);
@@ -118,31 +112,5 @@ class SnapshotTest extends TestCase
     {
         $snapshot = new Snapshot($this->blacklist, false, false, false, false, false, false, false, false, true);
         $this->assertContains(__FILE__, $snapshot->includedFiles());
-    }
-
-    /**
-     * Check global variable whose value is null are correctly backuped and restored.
-     *
-     * The real test is the second, but the first has to be executed to backup the globals.
-     *
-     * @backupGlobals enabled
-     */
-    public function testNullGlobalVariable()
-    {
-	$this->assertEquals(false, $GLOBALS['varBool']);
-        $this->assertArrayHasKey('varNull', $GLOBALS);
-        $this->assertEquals(null, $GLOBALS['varNull']);
-    }
-
-    /**
-     * Check global variable whose value is null are correctly backuped and restored.
-     *
-     * @depends testNullGlobalVariable
-     */
-    public function testNullGlobalVariable2()
-    {
-	$this->assertEquals(false, $GLOBALS['varBool']);
-        $this->assertArrayHasKey('varNull', $GLOBALS);
-        $this->assertEquals(null, $GLOBALS['varNull']);
     }
 }


### PR DESCRIPTION
Fixes #10 

----

I’m not sure if the same should be done for super-globals.