### PR TITLE
Fix: Remove sudo configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ php:
   - 7.3
   - 7.4snapshot
 
-sudo: false
-
 before_install:
   - composer self-update
   - composer clear-cache


### PR DESCRIPTION
This PR

* [x] removes outdated `sudo` configuration from `.travis.yml`

💁‍♂️ For reference, see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration.