### PR TITLE
Fix: Work around build failures on PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: php
 
+addons:
+  apt:
+    packages:
+      - libonig-dev
+
 php:
   - 7.2
   - 7.3


### PR DESCRIPTION
This PR

* [x] works around build failures on PHP 7.4