### PR TITLE
Fix: Blacklist interface to avoid flaky tests

### DIFF
--- a/tests/SnapshotTest.php
+++ b/tests/SnapshotTest.php
@@ -76,6 +76,8 @@ final class SnapshotTest extends TestCase
 
     public function testInterfaces(): void
     {
+        $this->blacklist->addClass(BlacklistedInterface::class);
+
         $snapshot   = new Snapshot($this->blacklist, false, false, false, false, false, true, false, false, false);
         $interfaces = $snapshot->interfaces();
 


### PR DESCRIPTION
This PR

* [x] blacklists the `BlacklistedInterface` to avoid flaky tests

💁‍♂️ In case the `BlacklistedInterface` has not been used before, it will not get blacklisted by https://github.com/sebastianbergmann/global-state/blob/c1bf4f7dc95cd0f581bc9278878510cc2c8849fd/tests/SnapshotTest.php#L110-L119 and this test will fail (which it did for me).