### PR TITLE
Skip uninitialised typed static attributes

### DIFF
--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -315,6 +315,11 @@ class Snapshot
                     }
 
                     $attribute->setAccessible(true);
+
+                    if (PHP_VERSION_ID >= 70400 && !$attribute->isInitialized()) {
+                        continue;
+                    }
+
                     $value = $attribute->getValue();
 
                     if ($this->canBeSerialized($value)) {

--- a/tests/_fixture/SnapshotClassTyped.php
+++ b/tests/_fixture/SnapshotClassTyped.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/global-state.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\GlobalState\TestFixture;
+
+class SnapshotClassTyped
+{
+    private static bool $bool = true;
+
+    private static string $string;
+
+    public static function init(): void
+    {
+        self::$string = 'string';
+    }
+}

--- a/tests/unit/SnapshotTest.php
+++ b/tests/unit/SnapshotTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use SebastianBergmann\GlobalState\TestFixture\ExcludedClass;
 use SebastianBergmann\GlobalState\TestFixture\ExcludedInterface;
 use SebastianBergmann\GlobalState\TestFixture\SnapshotClass;
+use SebastianBergmann\GlobalState\TestFixture\SnapshotClassTyped;
 use SebastianBergmann\GlobalState\TestFixture\SnapshotTrait;
 use stdClass;
 
@@ -40,7 +41,7 @@ final class SnapshotTest extends TestCase
     {
         SnapshotClass::init();
 
-        $this->excludeAllLoadedClassesExceptSnapshotClass();
+        $this->excludeAllLoadedClassesExceptClass(SnapshotClass::class);
 
         $snapshot = new Snapshot($this->excludeList, false, true, false, false, false, false, false, false, false);
 
@@ -48,6 +49,50 @@ final class SnapshotTest extends TestCase
             SnapshotClass::class => [
                 'string'  => 'string',
                 'objects' => [new stdClass],
+            ],
+        ];
+
+        $this->assertEquals($expected, $snapshot->staticAttributes());
+    }
+
+    public function testStaticNotInitialisedAttributes(): void
+    {
+        if (PHP_VERSION_ID < 70400) {
+            $this->markTestSkipped('Requires PHP 7.4+');
+        }
+
+        /* @noinspection PhpExpressionResultUnusedInspection */
+        new SnapshotClassTyped();
+
+        $this->excludeAllLoadedClassesExceptClass(SnapshotClassTyped::class);
+
+        $snapshot = new Snapshot($this->excludeList, false, true, false, false, false, false, false, false, false);
+
+        $expected = [
+            SnapshotClassTyped::class => [
+                'bool' => true,
+            ],
+        ];
+
+        $this->assertEquals($expected, $snapshot->staticAttributes());
+    }
+
+    public function testStaticInitialisedAttributes(): void
+    {
+        if (PHP_VERSION_ID < 70400) {
+            $this->markTestSkipped('Requires PHP 7.4+');
+        }
+
+        SnapshotClassTyped::init();
+
+        $this->excludeAllLoadedClassesExceptClass(SnapshotClassTyped::class);
+
+        $snapshot = new Snapshot($this->excludeList, false, true, false, false, false, false, false, false, false);
+
+        $expected = [
+            SnapshotClassTyped::class => [
+                'bool'   => true,
+                'string' => 'string',
             ],
         ];
 
@@ -160,10 +205,10 @@ final class SnapshotTest extends TestCase
         $this->assertContains(__FILE__, $snapshot->includedFiles());
     }
 
-    private function excludeAllLoadedClassesExceptSnapshotClass(): void
+    private function excludeAllLoadedClassesExceptClass(string $excludedClass): void
     {
         foreach (get_declared_classes() as $class) {
-            if ($class === SnapshotClass::class) {
+            if ($class === $excludedClass) {
                 continue;
             }
 


### PR DESCRIPTION
I've recently seen my phpunit CI faling [here](https://revive.beccati.com/bamboo/browse/PHP-PHPUN-2849):

```
PHPUnit\Event\DispatchingEmitterTest::testGlobalStateCapturedDispatchesGlobalStateCapturedEvent
Error: Typed static property SebastianBergmann\Environment\Runtime::$binary must not be accessed before initialization

/.../PHP-PHPUN-PHP80/vendor/sebastian/global-state/src/Snapshot.php:259
/.../PHP-PHPUN-PHP80/vendor/sebastian/global-state/src/Snapshot.php:91
/.../PHP-PHPUN-PHP80/tests/unit/Event/DispatchingEmitterTest.php:247
```

This seemed to be the proper fix.