### PR TITLE
Avoid `setAccessible()`

### DIFF
--- a/src/Restorer.php
+++ b/src/Restorer.php
@@ -53,7 +53,6 @@ final class Restorer
         foreach ($snapshot->staticProperties() as $className => $staticProperties) {
             foreach ($staticProperties as $name => $value) {
                 $reflector = new ReflectionProperty($className, $name);
-                $reflector->setAccessible(true);
                 $reflector->setValue($value);
             }
         }
@@ -77,7 +76,6 @@ final class Restorer
                     continue;
                 }
 
-                $property->setAccessible(true);
                 $property->setValue($defaults[$name]);
             }
         }

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -244,8 +244,6 @@ class Snapshot
                         continue;
                     }
 
-                    $property->setAccessible(true);
-
                     if (!$property->isInitialized()) {
                         continue;
                     }


### PR DESCRIPTION
setAccessible() is a no-op since PHP 8.1
and can be removed.